### PR TITLE
fix: remove redundant pkg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ torch==2.0.1
 tqdm==4.64.1
 jieba
 pandas
-json


### PR DESCRIPTION
python默认自带json库，删除冗余的行，否则会报错：

<img width="838" alt="image" src="https://github.com/DLLXW/baby-llama2-chinese/assets/45117727/e29befba-ee06-42ba-b18a-f85586e17a94">
