### PR TITLE
Windows support modifications in pretrain process

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ python data_process.py
 
 ```python
 #预训练
+因为用到了torch的分布式训练，我们需要在运行的时候设置环境变量。使用python -m torch.distributed.launch --use_env pretrain.py，或直接使用torchrun替代python命令。
 python pretrain.py
 #SFT
 python sft.py

--- a/pretrain.py
+++ b/pretrain.py
@@ -212,7 +212,13 @@ if __name__=="__main__":
     ddp = int(os.environ.get("RANK", -1)) != -1  # is this a ddp run?
     
     if ddp:
-        init_process_group(backend="nccl")
+        # Check if the operating system is Windows
+        if os.name == 'nt':
+            # Diff between backends: https://pytorch.org/docs/stable/distributed.html
+            init_process_group(backend="gloo")
+        else:
+            # If the operating system is Linux based, os.name == 'posix'
+            init_process_group(backend="nccl")
         ddp_rank = int(os.environ["RANK"])
         ddp_local_rank = int(os.environ["LOCAL_RANK"])
         ddp_world_size = int(os.environ["WORLD_SIZE"])
@@ -267,7 +273,7 @@ if __name__=="__main__":
         pin_memory=False,
         drop_last=False,
         shuffle=False,        
-        num_workers=4,
+        num_workers=0 if os.name == 'nt' else 4,
         sampler=train_sampler
     )
     # val_ds = PretrainDataset(data_path_list, max_length=256)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pytest==7.4.0
 Requests==2.31.0
 sentencepiece==0.1.99
 torch==2.0.1
+scikit-learn==1.3.0
 tqdm==4.64.1
 jieba
 pandas


### PR DESCRIPTION
**Modified pretrain.py :** Did a couple of changes for Windows compatibility, which will not affect the integrity and functionality of the original code for Linux/Unix-based OS.

- Regarding the nccl backend, there is no official nccl support for Windows, and the third-party nccl for Windows only supports CUDA 11 which implies very limited version compatibility. So I changed the backend to gloo when the operating system is Windows.
- "OSError: [Errno 22] Invalid argument" and "_pickle.UnpicklingError: pickle data was truncated" will occur when using the torch.utils.data.DataLoader class for loading data in a multiprocess mode. This may happen to the Windows environment. The serialize and deserialize process using pickle may fail when doing fork-based multiprocessing because it is not supported in Windows. The error message implies a truncation happened to the pickle file in the multiprocessing module. There is no known solution for this issue, so the current workaround is to disable multiprocessing and use the main process to load data instead by setting num_workers=0, only when the OS is Windows. _This shall be marked as an open issue to the Windows platform support and we may come back for it later._

**Modified requirement.txt :** Added scikit-learn as the dependency.
**Modified README.md :** Added instructions on how to run PyTorch with distributed training and automatically set the environment variables.