### PR TITLE
fix: multi gpu ddp save error

### DIFF
--- a/pretrain.py
+++ b/pretrain.py
@@ -94,10 +94,11 @@ def train_epoch(epoch):
                         spend_time / (step+1) * iter_per_epoch // 60 - spend_time // 60))
         #
         if step % save_interval == 0:
-            if ddp and torch.distributed.get_rank() == 0:
-                model.eval()
-                torch.save(model.module.state_dict(),'{}/iter_{}.pth'.format(save_dir,int(step+epoch*iter_per_epoch)))
-                model.train()
+            if ddp:
+                if torch.distributed.get_rank() == 0:
+                    model.eval()
+                    torch.save(model.module.state_dict(),'{}/iter_{}.pth'.format(save_dir,int(step+epoch*iter_per_epoch)))
+                    model.train()
             else:
                 model.eval()
                 torch.save(model.state_dict(),'{}/iter_{}.pth'.format(save_dir,int(step+epoch*iter_per_epoch)))
@@ -323,8 +324,9 @@ if __name__=="__main__":
     for epoch in range(max_epoch):
         train_epoch(epoch)
         #val_loss=valid_epoch(epoch)
-        if ddp and torch.distributed.get_rank() == 0:  #一般用0，当然，可以选任意的rank保存。
-            torch.save(raw_model.state_dict(),'{}/epoch_{}.pth'.format(save_dir,epoch))
+        if ddp:
+            if torch.distributed.get_rank() == 0:  #一般用0，当然，可以选任意的rank保存。
+                torch.save(raw_model.state_dict(),'{}/epoch_{}.pth'.format(save_dir,epoch))
         else:
             torch.save(raw_model.state_dict(),'{}/epoch_{}.pth'.format(save_dir,epoch))
     if ddp:

--- a/sft.py
+++ b/sft.py
@@ -316,8 +316,9 @@ if __name__=="__main__":
     for epoch in range(max_epoch):
         train_epoch(epoch)
         #val_loss=valid_epoch(epoch)
-        if ddp and torch.distributed.get_rank() == 0:
-            torch.save(raw_model.state_dict(),'{}/epoch_{}.pth'.format(save_dir,epoch))
+        if ddp:
+            if torch.distributed.get_rank() == 0:
+                torch.save(raw_model.state_dict(),'{}/epoch_{}.pth'.format(save_dir,epoch))
         else:
             torch.save(raw_model.state_dict(),'{}/epoch_{}.pth'.format(save_dir,epoch))
     if ddp:


### PR DESCRIPTION
当使用超过1个cpu，并且使用ddp的时候，save模型的代码if和else里的torch.save分别会被LOCAL_RANK=0以及LOCAL_RANK>=1的进程执行，会导致同时保存多次模型数据到同一个文件当中，导致save的数据torch.load报错
```shell
RuntimeError: PytorchStreamReader failed reading file byteorder: invalid header or archive is corrupted
```
  
  

当2个gpu执行时：
```python
# 满足 if 条件
ddp = True , LOCAL_RANK=0

# 满足 else 条件
ddp = True,  LOCAL_RANK=1
```
导致save了2次